### PR TITLE
Make files copied from host to user home fully accessible to user

### DIFF
--- a/pacstall-docker-builder
+++ b/pacstall-docker-builder
@@ -320,7 +320,7 @@ RUN if [[ \$(dpkg --print-architecture) == "amd64" ]]; then \
     fi && \
     apt-get update && \
     apt-get dist-upgrade -y && \
-    apt-get install wget curl git sudo nano ca-certificates util-linux adduser -y --fix-missing --no-install-recommends && \
+    apt-get install wget curl git sudo nano ca-certificates util-linux adduser acl -y --fix-missing --no-install-recommends && \
     apt-get clean && \
     apt-get autoclean && \
     apt-get autoremove -y
@@ -328,6 +328,7 @@ RUN adduser --disabled-password --gecos '' pacstall && adduser pacstall sudo
 RUN echo N | sudo bash -c "\$(curl -fsSL https://raw.githubusercontent.com/pacstall/pacstall/${imgver}/install.sh || wget -q https://raw.githubusercontent.com/pacstall/pacstall/${imgver}/install.sh -O -)" && rm -f /var/cache/apt/archives/*.deb /var/cache/apt/archives/partial/*.deb /var/cache/apt/*.bin
 RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 RUN chown -R pacstall:pacstall /var/log/pacstall && chown -R pacstall:pacstall /tmp/pacstall
+RUN setfacl -d -m user:pacstall:rwX /home/pacstall
 RUN sudo sed -i 's/ignore_stack=false/ignore_stack=true/g' /usr/bin/pacstall
 RUN runuser -l pacstall -c "HOME=/home/pacstall SUDO_USER=pacstall pacstall -U pacstall:${imgver}"
 # https://askubuntu.com/a/1026978


### PR DESCRIPTION
The general use case is to start a container from the generated image, to copy a script ready to be tested from the host to the container, and then to invoke the script in the container.

In some cases, it is required to copy additional files to the container. For example, to avoid repeated downloading of the same sources for successive tests, some sources may be maintained as local copies within the test environment. In such cases, it may be a directory, not a single file, copied from the host to the container after being created.

Due to a combination of factors, files copied from the host system are not writable to the default user, and neither are directories navigable. Notably, the owner of such files is set to the user of the base image, not the user declared, as an override, by the derived image. The reason is likely deliberately chosen by the container system to preserve compatibility among images sharing a common base.

Regardless, the proposed modification, utilizing ACLs, harmlessly corrects a disruption of usability presently emerging in particular cases.

As a further note, it may be worth considering whether it is necessary for the derived image to provision an additional user, rather than simply relying on the user provided by the base image.

If the new user is preserved, then the same mechanism of adding ACLs may be preferred to the current operation of changing ownership of essential locations.

