### PR TITLE
Resolve warnings at end of build process concerninge legacy label format

### DIFF
--- a/pacstall-docker-builder
+++ b/pacstall-docker-builder
@@ -307,7 +307,7 @@ fi
 function cat_built_dock {
   cat > ${built_dock} << EOF
 FROM ${base_darch}${base_distro}
-LABEL org.opencontainers.image.description "Contains pacstall:${imgver} from ${dateiniso}"
+LABEL org.opencontainers.image.description="Contains pacstall:${imgver} from ${dateiniso}"
 
 SHELL ["/bin/bash", "-l", "-c"]
 ARG DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
With newer versions of Docker, the following warning is generated:

```
LegacyKeyValueFormat: "LABEL key=value" should be used instead of legacy "LABEL key value" format (line 2)
```

The behavior is confirmed in Docker 29.3.0.

This commit resolves the warning.