### PR TITLE
Make man reader utility (i.e. command `man`) available from container

### DIFF
--- a/pacstall-docker-builder
+++ b/pacstall-docker-builder
@@ -315,12 +315,13 @@ ENV TZ="Africa/Libreville"
 RUN ln -snf /usr/share/zoneinfo/\$TZ /etc/localtime && echo \$TZ > /etc/timezone
 ARG package="pacstall"
 
+RUN dpkg-divert --rename --remove /usr/bin/man
 RUN if [[ \$(dpkg --print-architecture) == "amd64" ]]; then \
         dpkg --add-architecture i386; \
     fi && \
     apt-get update && \
     apt-get dist-upgrade -y && \
-    apt-get install wget curl git sudo nano ca-certificates util-linux adduser -y --fix-missing --no-install-recommends && \
+    apt-get install wget curl git sudo nano ca-certificates util-linux adduser man-db -y --fix-missing --no-install-recommends && \
     apt-get clean && \
     apt-get autoclean && \
     apt-get autoremove -y


### PR DESCRIPTION
To reduce usage of space, the utility is not included in the base image, which is designed primarily for contexts of substantial automation.

Availability of the utility allows reading the man page for Pacstall, from within the container, and also facilitates testing proper installation of man pages that may be included in any packages being tested.